### PR TITLE
Change timeout / wait settings on HF Helper

### DIFF
--- a/src/steamship/utils/huggingface_helper.py
+++ b/src/steamship/utils/huggingface_helper.py
@@ -17,7 +17,7 @@ from steamship import Block, SteamshipError
 
 
 async def _model_call(session, text: str, api_url, headers, additional_params: dict = None) -> list:
-    json_input = dict(inputs=text, wait_for_model=True, parameters=additional_params)
+    json_input = dict(inputs=text, wait_for_model=False, parameters=additional_params)
     data = json.dumps(json_input)
 
     max_error_retries = 3

--- a/src/steamship/utils/huggingface_helper.py
+++ b/src/steamship/utils/huggingface_helper.py
@@ -54,7 +54,7 @@ async def _model_call(session, text: str, api_url, headers, additional_params: d
 async def _model_calls(
     texts: List[str], api_url: str, headers, additional_params: dict = None
 ) -> List[list]:
-    async with aiohttp.ClientSession(timeout=ClientTimeout(total=10)) as session:
+    async with aiohttp.ClientSession(timeout=ClientTimeout(total=30)) as session:
         tasks = []
         for text in texts:
             tasks.append(

--- a/src/steamship/utils/huggingface_helper.py
+++ b/src/steamship/utils/huggingface_helper.py
@@ -52,9 +52,13 @@ async def _model_call(session, text: str, api_url, headers, additional_params: d
 
 
 async def _model_calls(
-    texts: List[str], api_url: str, headers, additional_params: dict = None
+    texts: List[str],
+    api_url: str,
+    headers,
+    timeout_seconds: int,
+    additional_params: dict = None,
 ) -> List[list]:
-    async with aiohttp.ClientSession(timeout=ClientTimeout(total=30)) as session:
+    async with aiohttp.ClientSession(timeout=ClientTimeout(total=timeout_seconds)) as session:
         tasks = []
         for text in texts:
             tasks.append(
@@ -70,13 +74,23 @@ async def _model_calls(
 
 
 def get_huggingface_results(
-    blocks: List[Block], hf_model_path: str, hf_bearer_token: str, additional_params: dict = None
+    blocks: List[Block],
+    hf_model_path: str,
+    hf_bearer_token: str,
+    additional_params: dict = None,
+    timeout_seconds: int = 30,
 ) -> List[list]:
     api_url = f"https://api-inference.huggingface.co/models/{hf_model_path}"
     headers = {"Authorization": f"Bearer {hf_bearer_token}"}
     start_time = time.perf_counter()
     results = asyncio.run(
-        _model_calls([block.text for block in blocks], api_url, headers, additional_params)
+        _model_calls(
+            [block.text for block in blocks],
+            api_url,
+            headers,
+            timeout_seconds=timeout_seconds,
+            additional_params=additional_params,
+        )
     )
     total_time = time.perf_counter() - start_time
     logging.info(


### PR DESCRIPTION
- Set default timeout to 30 sec instead of 10
- Allow passing timeout per usage
- Don't tell HF to wait on the model per call