### PR TITLE
Support url-conveyed data in RawDataPluginInput

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,6 +25,7 @@ Set up your virtual environment using the following commands:
 ```
 python3 -m venv .venv
 source .venv/bin/activate
+python -m pip install -r requirements.txt
 python -m pip install -r requirements.dev.txt
 ```
 

--- a/src/steamship/plugin/inputs/raw_data_plugin_input.py
+++ b/src/steamship/plugin/inputs/raw_data_plugin_input.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from steamship.base.mime_types import TEXT_MIME_TYPES
+from steamship.utils.signed_urls import url_to_bytes
 
 
 def is_base64(sb):
@@ -24,12 +25,33 @@ def is_base64(sb):
 
 
 class RawDataPluginInput(BaseModel):
+    """Input for a plugin that accepts raw data, plus a mime type.
+
+    A plugin author need only ever concern themselves with two fields:
+    - `data` - Raw bytes
+    ` `default_mime_type` - The best guess as to `data`'s MIME Type unless otherwise known to be different.
+
+    In practice, however, the lifecycle of this object involves a but more under the hood:
+
+    - **Potentially Base64 Decoding Data**. When decoding from a dict, the `data` field is assumed to be Base64 encoded.
+      This is to support JSON as a transport encoding over the wire. The constructor automatically performs the
+      decoding, and the Steamship Engine automatically performs the encoding, so the Plugin Author can mostly ignore
+      this fact.
+
+    - **Potentially late-fetching the `data` from a `url`**. Some files are too large to comfortably send as Base64
+      within JSON. The Steamship Engine sometimes chooses to send an empty `data` field paired with a non-empty
+      `url` field. When this happens, the constructor proactively, synchronously fetches the contents of that `url`
+      and assigns it to the `data` field, throwing a SteamshipError if the fetch fails. Again, this is done
+      automatically so the Plugin Author can mostly ignore this fact.
+    """
+
     plugin_instance: str = None
     data: Any = None
     default_mime_type: str = None
 
     def __init__(self, **kwargs):
         data = kwargs.get("data")
+        url = kwargs.get("data")
 
         if data is not None and is_base64(data):
             data_bytes = base64.b64decode(data)
@@ -37,5 +59,7 @@ class RawDataPluginInput(BaseModel):
                 kwargs["data"] = data_bytes.decode("utf-8")
             else:
                 kwargs["data"] = data_bytes
+        elif url is not None:
+            self.data = url_to_bytes(url)
 
         super().__init__(**kwargs)

--- a/src/steamship/plugin/inputs/raw_data_plugin_input.py
+++ b/src/steamship/plugin/inputs/raw_data_plugin_input.py
@@ -31,7 +31,7 @@ class RawDataPluginInput(BaseModel):
     - `data` - Raw bytes
     ` `default_mime_type` - The best guess as to `data`'s MIME Type unless otherwise known to be different.
 
-    In practice, however, the lifecycle of this object involves a but more under the hood:
+    In practice, however, the lifecycle of this object involves a bit more under the hood:
 
     - **Potentially Base64 Decoding Data**. When decoding from a dict, the `data` field is assumed to be Base64 encoded.
       This is to support JSON as a transport encoding over the wire. The constructor automatically performs the

--- a/src/steamship/plugin/inputs/raw_data_plugin_input.py
+++ b/src/steamship/plugin/inputs/raw_data_plugin_input.py
@@ -60,6 +60,9 @@ class RawDataPluginInput(BaseModel):
             else:
                 kwargs["data"] = data_bytes
         elif url is not None:
-            self.data = url_to_bytes(url)
+            kwargs["data"] = url_to_bytes(url)  # Resolve the URL into the data field
+            kwargs.pop(
+                "url"
+            )  # Remove the URL field to preserve a simple interface for the consumer
 
         super().__init__(**kwargs)

--- a/src/steamship/plugin/inputs/raw_data_plugin_input.py
+++ b/src/steamship/plugin/inputs/raw_data_plugin_input.py
@@ -51,7 +51,7 @@ class RawDataPluginInput(BaseModel):
 
     def __init__(self, **kwargs):
         data = kwargs.get("data")
-        url = kwargs.get("data")
+        url = kwargs.get("url")
 
         if data is not None and is_base64(data):
             data_bytes = base64.b64decode(data)

--- a/tests/assets/plugins/taggers/plugin_trainable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_trainable_tagger.py
@@ -86,6 +86,14 @@ class TestTrainableTaggerModel(TrainableModel[EmptyConfig]):
         self.keyword_list = input.training_params.get("keyword_list", [])
         return TRAIN_RESPONSE
 
+    def train_status(self, input: TrainStatusPluginInput) -> TrainPluginOutput:
+        """Training for this model is to set the parameters to those provided in the input object.
+
+        This allows us to test that we're properly passing through the training parameters to the train process.
+        """
+        logging.info("TestTrainableTaggerModel:train()")
+        return TRAIN_RESPONSE
+
     def run(
         self, request: PluginRequest[BlockAndTagPluginInput]
     ) -> Response[BlockAndTagPluginOutput]:

--- a/tests/assets/plugins/taggers/plugin_trainable_tagger_config.py
+++ b/tests/assets/plugins/taggers/plugin_trainable_tagger_config.py
@@ -20,7 +20,7 @@ from steamship.plugin.trainable_model import TrainableModel
 # If this isn't present, Localstack won't show logs
 logging.getLogger().setLevel(logging.INFO)
 
-TRAIN_RESPONSE = TrainPluginOutput()
+TRAIN_RESPONSE = TrainPluginOutput(training_complete=True)
 
 
 class TestConfig(Config):

--- a/tests/tests/plugin/unit/test_service.py
+++ b/tests/tests/plugin/unit/test_service.py
@@ -7,6 +7,7 @@ from steamship.app.response import Response
 from steamship.base import Client
 from steamship.plugin.config import Config
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
+from steamship.plugin.inputs.train_status_plugin_input import TrainStatusPluginInput
 from steamship.plugin.inputs.training_parameter_plugin_input import TrainingParameterPluginInput
 from steamship.plugin.outputs.train_plugin_output import TrainPluginOutput
 from steamship.plugin.outputs.training_parameter_plugin_output import TrainingParameterPluginOutput
@@ -29,6 +30,9 @@ class ValidTrainableStringToStringModel(TrainableModel[EmptyConfig]):
         pass
 
     def train(self, input: TrainPluginInput) -> TrainPluginOutput:
+        pass
+
+    def train_status(self, input: TrainStatusPluginInput) -> TrainPluginOutput:
         pass
 
     def save_to_folder(self, checkpoint_path: Path):
@@ -56,7 +60,12 @@ class ValidTrainableStringToStringPlugin(TrainableTagger):
         return Response(data=TrainingParameterPluginOutput())
 
     def train(self, request: PluginRequest[TrainPluginInput], model) -> Response[TrainPluginOutput]:
-        return Response(data=TrainPluginOutput())
+        return Response(data=TrainPluginOutput(training_complete=True))
+
+    def train_status(
+        self, request: PluginRequest[TrainStatusPluginInput], model
+    ) -> Response[TrainPluginOutput]:
+        return Response(data=TrainPluginOutput(training_complete=True))
 
 
 #

--- a/tests/tests/plugin/unit/test_trainable_tagger.py
+++ b/tests/tests/plugin/unit/test_trainable_tagger.py
@@ -5,7 +5,6 @@ from assets.plugins.taggers.plugin_trainable_tagger import (
 )
 
 from steamship import File
-from steamship.base.utils import to_camel
 from steamship.data.block import Block
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
@@ -69,7 +68,7 @@ def test_trainable_tagger():
         ),
         model,
     )
-    assert tagger1.data == {to_camel(k): v for (k, v) in TRAIN_RESPONSE.dict().items()}
+    assert tagger1.data == TRAIN_RESPONSE.dict(by_alias=True)
 
     tagger2 = plugin.train_endpoint(
         **PluginRequest(
@@ -80,7 +79,7 @@ def test_trainable_tagger():
             plugin_instance_id="000",
         ).dict()
     )
-    assert tagger2.data == {to_camel(k): v for (k, v) in TRAIN_RESPONSE.dict().items()}
+    assert tagger2.data == TRAIN_RESPONSE.dict(by_alias=True)
 
     # STEP 3. Run
     res = plugin.run(TEST_PLUGIN_REQ)

--- a/tests/tests/plugin/unit/test_trainable_tagger.py
+++ b/tests/tests/plugin/unit/test_trainable_tagger.py
@@ -5,6 +5,7 @@ from assets.plugins.taggers.plugin_trainable_tagger import (
 )
 
 from steamship import File
+from steamship.base.utils import to_camel
 from steamship.data.block import Block
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
@@ -68,7 +69,7 @@ def test_trainable_tagger():
         ),
         model,
     )
-    assert tagger1.data == TRAIN_RESPONSE.dict()
+    assert tagger1.data == {to_camel(k): v for (k, v) in TRAIN_RESPONSE.dict().items()}
 
     tagger2 = plugin.train_endpoint(
         **PluginRequest(
@@ -79,7 +80,7 @@ def test_trainable_tagger():
             plugin_instance_id="000",
         ).dict()
     )
-    assert tagger2.data == TRAIN_RESPONSE.dict()
+    assert tagger2.data == {to_camel(k): v for (k, v) in TRAIN_RESPONSE.dict().items()}
 
     # STEP 3. Run
     res = plugin.run(TEST_PLUGIN_REQ)

--- a/tests/tests/plugin/unit/test_trainable_tagger_config.py
+++ b/tests/tests/plugin/unit/test_trainable_tagger_config.py
@@ -1,10 +1,17 @@
-from assets.plugins.taggers.plugin_trainable_tagger_config import TestTrainableTaggerConfigPlugin
+from unittest.mock import patch
+
+from assets.plugins.taggers.plugin_trainable_tagger_config import (
+    TestConfig,
+    TestTrainableTaggerConfigModel,
+    TestTrainableTaggerConfigPlugin,
+)
 
 from steamship import File
 from steamship.data.block import Block
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
 from steamship.plugin.service import PluginRequest
+from steamship.plugin.trainable_model import TrainableModel
 from tests.utils.fixtures import get_steamship_client
 
 TEST_REQ = BlockAndTagPluginInput(
@@ -26,20 +33,26 @@ def test_trainable_tagger():
     client = get_steamship_client()
     assert client is not None
 
-    plugin = TestTrainableTaggerConfigPlugin(
-        client=client, config=dict(testValue1="foo", testValue2="bar")
-    )
-    assert plugin.client is not None
+    def load_remote(**kwargs):
+        model = TestTrainableTaggerConfigModel()
+        model.receive_config(TestConfig(testValue1=1, testValue2=2))
+        return model
 
-    # Make sure plugin model gets its config while 'training'.
+    # There isn't ACTUALLY model data to load..
+    with patch.object(TrainableModel, "load_remote", load_remote):
+        plugin = TestTrainableTaggerConfigPlugin(
+            client=client, config=dict(testValue1="foo", testValue2="bar")
+        )
+        assert plugin.client is not None
 
-    tagger2 = plugin.train_endpoint(
-        **PluginRequest(
-            data=TrainPluginInput(plugin_instance="foo", training_params=None),
-            task_id="000",
-            plugin_instance_id="000",
-        ).dict()
-    )
+        # Make sure plugin model gets its config while 'training'.
+        plugin.train_endpoint(
+            **PluginRequest(
+                data=TrainPluginInput(plugin_instance="foo", training_params=None),
+                task_id="000",
+                plugin_instance_id="000",
+            ).dict()
+        )
 
-    # Make sure plugin model gets its config while 'running'
-    res = plugin.run(TEST_PLUGIN_REQ)
+        # Make sure plugin model gets its config while 'running'
+        plugin.run(TEST_PLUGIN_REQ)


### PR DESCRIPTION
Some files are too large to comfortably send as Base64
      within JSON. The Steamship Engine sometimes chooses to send an empty `data` field paired with a non-empty
      `url` field. When this happens, the constructor proactively, synchronously fetches the contents of that `url`
      and assigns it to the `data` field, throwing a SteamshipError if the fetch fails. Again, this is done
      automatically so the Plugin Author can mostly ignore this fact.