### PR TITLE
Unit test expected error responses of apps/plugins

### DIFF
--- a/src/steamship/app/lambda_handler.py
+++ b/src/steamship/app/lambda_handler.py
@@ -56,7 +56,7 @@ def create_handler(app_cls: Type[App]):
             return Response.error(
                 code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 prefix=error_prefix,
-                message=f"Unable to initialize plugin/app. {ex}",
+                message=f"Unable to initialize plugin/app.",
                 exception=ex,
             )
 

--- a/src/steamship/app/request.py
+++ b/src/steamship/app/request.py
@@ -49,7 +49,5 @@ class Request(BaseModel):
     is intended to execute.
     """
 
-    # TODO (enias): Is this a replacement for the Request in base?
-    # FROM (ted): No; this is the request object a
     clientConfig: Configuration = None
     invocation: Invocation = None

--- a/src/steamship/app/request.py
+++ b/src/steamship/app/request.py
@@ -39,13 +39,17 @@ class Invocation(BaseModel):
 
 
 class Request(BaseModel):
-    """An request of a method on an app instance.
+    """A request as the Steamship Hosting Framework receives it from the Engine.
 
-    This is the payload sent from the public-facing App Proxy to the
-    private-facing app microservice.
+    This class is different from the other `Request` class:
+     * `steamship.base.request` represents a request from the Steamship Client
+     * this class represents a request from the Steamship Engine to a Steamship-hosted App/Plugin
+
+    It contains both an app/plugin invocation and also the client configuration in which that invocation
+    is intended to execute.
     """
 
     # TODO (enias): Is this a replacement for the Request in base?
-
+    # FROM (ted): No; this is the request object a
     clientConfig: Configuration = None
     invocation: Invocation = None

--- a/src/steamship/base/error.py
+++ b/src/steamship/base/error.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Union
 
+DEFAULT_ERROR_MESSAGE = "Undefined remote error"
+
 
 class SteamshipError(Exception):
     message: str = None
@@ -13,7 +15,7 @@ class SteamshipError(Exception):
 
     def __init__(
         self,
-        message: str = "Undefined remote error",
+        message: str = DEFAULT_ERROR_MESSAGE,
         internal_message: str = None,
         suggestion: str = None,
         code: str = None,

--- a/tests/assets/apps/demo_app.py
+++ b/tests/assets/apps/demo_app.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from pydantic import BaseModel
 
+from steamship import SteamshipError
 from steamship.app import App, Response, create_handler, get, post
 from steamship.base import Client
 from steamship.base.mime_types import MimeTypes
@@ -62,6 +63,14 @@ class TestApp(App):
     @get("space")
     def space(self) -> Response:
         return Response(string=self.client.config.space_id)
+
+    @post("raise_steamship_error")
+    def raise_steamship_error(self) -> Response:
+        raise SteamshipError(message="raise_steamship_error")
+
+    @post("raise_python_error")
+    def raise_python_error(self) -> Response:
+        raise Exception("raise_python_error")
 
     @post("user_info")
     def user_info(self) -> Response:

--- a/tests/assets/plugins/importers/plugin_file_importer_python_error.py
+++ b/tests/assets/plugins/importers/plugin_file_importer_python_error.py
@@ -1,0 +1,22 @@
+from typing import Type
+
+from steamship.app import Response, create_handler
+from steamship.plugin.config import Config
+from steamship.plugin.file_importer import FileImporter
+from steamship.plugin.inputs.file_import_plugin_input import FileImportPluginInput
+from steamship.plugin.outputs.raw_data_plugin_output import RawDataPluginOutput
+from steamship.plugin.service import PluginRequest
+
+
+class TestFileImporterPythonErrorPlugin(FileImporter):
+    class EmptyConfig(Config):
+        pass
+
+    def config_cls(self) -> Type[Config]:
+        return self.EmptyConfig
+
+    def run(self, request: PluginRequest[FileImportPluginInput]) -> Response[RawDataPluginOutput]:
+        raise Exception("TestFileImporterPythonErrorPlugin")
+
+
+handler = create_handler(TestFileImporterPythonErrorPlugin)

--- a/tests/assets/plugins/importers/plugin_file_importer_steamship_error.py
+++ b/tests/assets/plugins/importers/plugin_file_importer_steamship_error.py
@@ -1,0 +1,23 @@
+from typing import Type
+
+from steamship import SteamshipError
+from steamship.app import Response, create_handler
+from steamship.plugin.config import Config
+from steamship.plugin.file_importer import FileImporter
+from steamship.plugin.inputs.file_import_plugin_input import FileImportPluginInput
+from steamship.plugin.outputs.raw_data_plugin_output import RawDataPluginOutput
+from steamship.plugin.service import PluginRequest
+
+
+class TestFileImporterSteamshipErrorPlugin(FileImporter):
+    class EmptyConfig(Config):
+        pass
+
+    def config_cls(self) -> Type[Config]:
+        return self.EmptyConfig
+
+    def run(self, request: PluginRequest[FileImportPluginInput]) -> Response[RawDataPluginOutput]:
+        raise SteamshipError(message="TestFileImporterSteamshipErrorPlugin")
+
+
+handler = create_handler(TestFileImporterSteamshipErrorPlugin)

--- a/tests/tests/app/integration/test_app_error_visibility.py
+++ b/tests/tests/app/integration/test_app_error_visibility.py
@@ -1,0 +1,38 @@
+from typing import Callable, Optional
+
+import pytest
+
+from tests.assets.apps.demo_app import TestApp
+from tests.utils.fixtures import app_handler  # noqa: F401
+
+ERROR_NO_METHOD = "No handler for POST /method_doesnt_exist available."
+ERROR_STEAMSHIP_ERROR = "[ERROR - POST raise_steamship_error] raise_steamship_error"
+ERROR_PYTHON_ERROR = "[ERROR - POST raise_python_error] raise_python_error"
+
+
+@pytest.mark.parametrize("app_handler", [TestApp], indirect=True)
+def test_instance_invoke_unit(app_handler: Callable[[str, str, Optional[dict]], dict]):
+    """Test that the handler returns the proper errors"""
+
+    response = app_handler("POST", "method_doesnt_exist")
+    assert response.get("status", {}).get("statusMessage", "") == ERROR_NO_METHOD
+
+    response = app_handler("POST", "raise_steamship_error")
+    assert response.get("status", {}).get("statusMessage", "") == ERROR_STEAMSHIP_ERROR
+
+    response = app_handler("POST", "raise_python_error")
+    assert response.get("status", {}).get("statusMessage", "") == ERROR_PYTHON_ERROR
+
+
+@pytest.mark.parametrize("app_handler", [TestApp], indirect=True)
+def test_instance_invoke_unit(app_handler: Callable[[str, str, Optional[dict]], dict]):
+    """Test that the handler returns the proper errors"""
+
+    response = app_handler("POST", "method_doesnt_exist")
+    assert response.get("status", {}).get("statusMessage", "") == ERROR_NO_METHOD
+
+    response = app_handler("POST", "raise_steamship_error")
+    assert response.get("status", {}).get("statusMessage", "") == ERROR_STEAMSHIP_ERROR
+
+    response = app_handler("POST", "raise_python_error")
+    assert response.get("status", {}).get("statusMessage", "") == ERROR_PYTHON_ERROR

--- a/tests/utils/fixtures.py
+++ b/tests/utils/fixtures.py
@@ -1,6 +1,11 @@
+from typing import Callable, Optional, Type
+
 import pytest
 
 from steamship import Space, Steamship
+from steamship.app.app import App
+from steamship.app.lambda_handler import create_handler as _create_handler
+from steamship.app.request import Invocation, Request
 from tests.utils.client import get_steamship_client
 
 
@@ -8,9 +13,56 @@ from tests.utils.client import get_steamship_client
 def client() -> Steamship:
     """
     Returns a client rooted in a new space, then deletes that space afterwards.
+
+    To use, simply import this file and then write a test which takes `client`
+    as an argument. For example:
+
+    ```
+    from tests.utils.fixtures import client  # noqa: F401
+
+    def test_something(client):
+      pass #
+    ```
     """
     steamship = get_steamship_client()
     space = Space.create(client=steamship).data
     new_client = steamship.for_space(space_id=space.id)
     yield new_client
+    space.delete()
+
+
+@pytest.fixture
+def app_handler(request) -> Callable[[str, str, Optional[dict]], dict]:
+    """
+    Returns a client rooted in a new space, then deletes that space afterwards.
+
+    To use, simply import this file and then write a test which takes `app_handler`
+    as an argument and parameterize it via PyTest. For example:
+
+    ```
+    import pytest
+    from tests.utils.fixtures import app_handler  # noqa: F401
+
+    @pytest.mark.parametrize('app_handler', [TestApp], indirect=True)
+    def test_something(app_handler):
+      response_dict = app_handler('POST', '/hello', dict())
+    ```
+
+    The app will be run its own space that gets cleaned up afterwards, and
+    the test can be written from the perspective of an external caller of the
+    app.
+    """
+    app: Type[App] = request.param
+    steamship = get_steamship_client()
+    space = Space.create(client=steamship).data
+    new_client = steamship.for_space(space_id=space.id)
+
+    def handle(verb: str, app_path: str, arguments: Optional[dict] = None) -> dict:
+        _handler = _create_handler(app)
+        invocation = Invocation(httpVerb=verb, appPath=app_path, arguments=arguments or dict())
+        request = Request(clientConfig=new_client.config, invocation=invocation)
+        event = request.dict()
+        return _handler(event)
+
+    yield handle
     space.delete()


### PR DESCRIPTION
This is the Python-side work of building end-to-end Exception visibility into our test suite.

It tests that

* Unexpected python Exceptions
* thrown SteamshipErrors
* missing method calls

Are all reported to the user as an appropriately formatted SteamshipResponse object.

## Testing method

The built-in testing app now contains a few functions  which are intended to generate errors with known messages. The test invokes those functions and assertions are placed on the HTTP response object.

## Additional Improvements

This PR includes a PyTest fixture which makes it very easy to test a Steamship App from the perspective of the HTTP caller without actually doing a full deploy & round trip to the engine.

It is useful to have some tests which actually do this full round trip, but aside from testing that the round trip works, we probably want to refactor most tests to use this fixture so that they can run FAR faster than present.