### PR TITLE
Add guard against http://test

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -101,6 +101,7 @@ class Client(CamelModel, ABC):
                 and "127.0.0.1" not in base
                 and "0:0:0:0" not in base
                 and "host.docker.internal" not in base
+                and "/test:" not in base  # http://test:8081 - for use with GitHub actions
             ):
                 # We want to prepend the user handle
                 parts = base.split("//")

--- a/tests/utils/test_client.py
+++ b/tests/utils/test_client.py
@@ -1,6 +1,9 @@
 __copyright__ = "Steamship"
 __license__ = "MIT"
 
+import pytest
+
+from steamship import Configuration
 from steamship.data.user import User
 from tests.utils.fixtures import get_steamship_client
 
@@ -13,3 +16,42 @@ def test_get_steamship_client():
     user = User.current(client).data
     assert user.id is not None
     assert user.handle is not None
+
+
+@pytest.mark.parametrize(
+    "app_base,user,fixed_base",
+    [
+        pytest.param("http://test:8081", "user", "http://test:8081/"),
+        pytest.param("http://test:8081/", "user", "http://test:8081/"),
+        pytest.param("http://localhost:8081", "user", "http://localhost:8081/"),
+        pytest.param("http://localhost:8081/", "user", "http://localhost:8081/"),
+        pytest.param("http://127.0.0.1:8081", "user", "http://127.0.0.1:8081/"),
+        pytest.param("http://127.0.0.1:8081/", "user", "http://127.0.0.1:8081/"),
+        pytest.param(
+            "http://host.docker.internal:8081", "user", "http://host.docker.internal:8081/"
+        ),
+        pytest.param(
+            "http://host.docker.internal:8081/", "user", "http://host.docker.internal:8081/"
+        ),
+        pytest.param("http://0:0:0:0:8081", "user", "http://0:0:0:0:8081/"),
+        pytest.param("http://0:0:0:0:8081/", "user", "http://0:0:0:0:8081/"),
+        pytest.param("https://apps.steamship.run", "user", "https://user.apps.steamship.run/"),
+        pytest.param("https://apps.steamship.run/", "user", "https://user.apps.steamship.run/"),
+        pytest.param(
+            "https://apps.staging.steamship.com", "user", "https://user.apps.staging.steamship.com/"
+        ),
+        pytest.param(
+            "https://apps.staging.steamship.com/",
+            "user",
+            "https://user.apps.staging.steamship.com/",
+        ),
+    ],
+)
+def test_app_call_rewriting(app_base: str, user: str, fixed_base: str):
+    client = get_steamship_client()
+
+    OPERATION = "foo"
+
+    config = Configuration(app_base=app_base)
+    output_url = client._url(app_call=True, app_owner=user, operation=OPERATION, config=config)
+    assert output_url == f"{fixed_base}{OPERATION}"


### PR DESCRIPTION
This is a valid address for the Engine & Proxy from within Lambda when executing inside Localstack inside GitHub Actions.

As such, we need to add it to the list of URLs not to pre-pend the username to.