### PR TITLE
Swap out BaseModel in favour of CamelModel

### DIFF
--- a/src/steamship/app/app.py
+++ b/src/steamship/app/app.py
@@ -145,8 +145,8 @@ class App:
             self.logger.error(f"__call__: No invocation on request.")
             return Response.error(code=HTTPStatus.NOT_FOUND, message="No invocation was found.")
 
-        verb = Verb.safely_from_str(request.invocation.httpVerb)
-        path = request.invocation.appPath
+        verb = Verb.safely_from_str(request.invocation.http_verb)
+        path = request.invocation.app_path
 
         path = self._clean_path(path)
 

--- a/src/steamship/app/lambda_handler.py
+++ b/src/steamship/app/lambda_handler.py
@@ -51,7 +51,9 @@ def create_handler(app_cls: Type[App]):
             )
 
         if request and request.invocation:
-            error_prefix = f"[ERROR - {request.invocation.httpVerb} {request.invocation.appPath}] "
+            error_prefix = (
+                f"[ERROR - {request.invocation.http_verb} {request.invocation.app_path}] "
+            )
         else:
             error_prefix = f"[ERROR - ?VERB ?PATH] "
 

--- a/src/steamship/app/request.py
+++ b/src/steamship/app/request.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from pydantic import BaseModel
-
-from steamship.base.configuration import Configuration
+from steamship.base.configuration import CamelModel, Configuration
 
 
 def event_to_config(event: dict) -> Configuration:
@@ -16,19 +14,19 @@ def event_to_config(event: dict) -> Configuration:
     return Configuration.parse_obj(event["invocationContext"])
 
 
-class Invocation(BaseModel):
-    httpVerb: str = None
-    appPath: str = None  # e.g. /hello/there
+class Invocation(CamelModel):
+    http_verb: str = None
+    app_path: str = None  # e.g. /hello/there
     arguments: Dict[str, Any] = None
     config: Dict[str, Any] = None
 
 
-class LoggingConfig(BaseModel):
-    loggingHost: str = None
-    loggingPort: str = None
+class LoggingConfig(CamelModel):
+    logging_host: str = None
+    logging_port: str = None
 
 
-class Request(BaseModel):
+class Request(CamelModel):
     """A request as the Steamship Hosting Framework receives it from the Engine.
 
     This class is different from the other `Request` class:
@@ -39,6 +37,6 @@ class Request(BaseModel):
     is intended to execute.
     """
 
-    clientConfig: Configuration = None
+    client_config: Configuration = None
     invocation: Invocation = None
-    loggingConfig: LoggingConfig = None
+    logging_config: LoggingConfig = None

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -106,7 +106,7 @@ class TaskComment(CamelModel):
         )
 
 
-class TaskCommentList(BaseModel):
+class TaskCommentList(CamelModel):
     # TODO (enias): Not needed
     comments: List[TaskComment]
 

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -57,7 +57,7 @@ class File(CamelModel):
         filename: str = None
         type: FileUploadType = None
         mime_type: str = None
-        corpusId: str = None
+        corpus_id: str = None
         blocks: Optional[List[Block.CreateRequest]] = []
         tags: Optional[List[Tag.CreateRequest]] = []
         plugin_instance: str = None

--- a/src/steamship/data/user.py
+++ b/src/steamship/data/user.py
@@ -6,9 +6,10 @@ from pydantic import BaseModel
 
 from steamship.app import Response
 from steamship.base import Client
+from steamship.base.configuration import CamelModel
 
 
-class User(BaseModel):
+class User(CamelModel):
     client: Client = None
     id: str = None
     handle: str = None

--- a/src/steamship/plugin/config.py
+++ b/src/steamship/plugin/config.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel
+from steamship.base.configuration import CamelModel
 
 
-class Config(BaseModel):
+class Config(CamelModel):
     """Base class for a Steamship Plugin's configuration object."""
 
     def __init__(self, **kwargs):

--- a/src/steamship/plugin/inputs/block_and_tag_plugin_input.py
+++ b/src/steamship/plugin/inputs/block_and_tag_plugin_input.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-
 from steamship import File
+from steamship.base.configuration import CamelModel
 
 
-class BlockAndTagPluginInput(BaseModel):
+class BlockAndTagPluginInput(CamelModel):
     file: File = None

--- a/src/steamship/plugin/inputs/raw_data_plugin_input.py
+++ b/src/steamship/plugin/inputs/raw_data_plugin_input.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import base64
 from typing import Any
 
-from pydantic import BaseModel
-
+from steamship.base.configuration import CamelModel
 from steamship.base.mime_types import TEXT_MIME_TYPES
 from steamship.utils.signed_urls import url_to_bytes
 
@@ -24,7 +23,7 @@ def is_base64(sb):
         return False
 
 
-class RawDataPluginInput(BaseModel):
+class RawDataPluginInput(CamelModel):
     """Input for a plugin that accepts raw data, plus a mime type.
 
     A plugin author need only ever concern themselves with two fields:

--- a/src/steamship/plugin/outputs/block_and_tag_plugin_output.py
+++ b/src/steamship/plugin/outputs/block_and_tag_plugin_output.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-
+from steamship.base.configuration import CamelModel
 from steamship.data.file import File
 
 
-class BlockAndTagPluginOutput(BaseModel):
+class BlockAndTagPluginOutput(CamelModel):
     file: File.CreateRequest = None

--- a/src/steamship/plugin/outputs/embedded_items_plugin_output.py
+++ b/src/steamship/plugin/outputs/embedded_items_plugin_output.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import List
 
-from pydantic import BaseModel
+from steamship.base.configuration import CamelModel
 
 
-class EmbeddedItemsPluginOutput(BaseModel):
+class EmbeddedItemsPluginOutput(CamelModel):
     embeddings: List[List[float]]

--- a/tests/assets/apps/demo_app.py
+++ b/tests/assets/apps/demo_app.py
@@ -3,16 +3,15 @@ import io
 from logging import Logger
 from typing import Any, Dict
 
-from pydantic import BaseModel
-
 from steamship import SteamshipError
 from steamship.app import App, Response, create_handler, get, post
 from steamship.base import Client
+from steamship.base.configuration import CamelModel
 from steamship.base.mime_types import MimeTypes
 from steamship.data.user import User
 
 
-class TestObj(BaseModel):
+class TestObj(CamelModel):
     name: str
 
 

--- a/tests/tests/app/integration/test_app_error_visibility.py
+++ b/tests/tests/app/integration/test_app_error_visibility.py
@@ -22,17 +22,3 @@ def test_instance_invoke_unit(app_handler: Callable[[str, str, Optional[dict]], 
 
     response = app_handler("POST", "raise_python_error")
     assert response.get("status", {}).get("statusMessage", "") == ERROR_PYTHON_ERROR
-
-
-@pytest.mark.parametrize("app_handler", [TestApp], indirect=True)
-def test_instance_invoke_unit(app_handler: Callable[[str, str, Optional[dict]], dict]):
-    """Test that the handler returns the proper errors"""
-
-    response = app_handler("POST", "method_doesnt_exist")
-    assert response.get("status", {}).get("statusMessage", "") == ERROR_NO_METHOD
-
-    response = app_handler("POST", "raise_steamship_error")
-    assert response.get("status", {}).get("statusMessage", "") == ERROR_STEAMSHIP_ERROR
-
-    response = app_handler("POST", "raise_python_error")
-    assert response.get("status", {}).get("statusMessage", "") == ERROR_PYTHON_ERROR

--- a/tests/tests/app/unit/test_response.py
+++ b/tests/tests/app/unit/test_response.py
@@ -42,4 +42,4 @@ def test_resp_response():
     d = r.dict()
     check_mime(d, MimeTypes.JSON)
     check_type(d, dict)
-    check_val(d, o.dict())
+    check_val(d, o.dict(by_alias=True))

--- a/tests/tests/base/test_binary_utils.py
+++ b/tests/tests/base/test_binary_utils.py
@@ -1,9 +1,8 @@
 import base64
 import json
 
-from pydantic import BaseModel
-
 from steamship.base.binary_utils import flexi_create
+from steamship.base.configuration import CamelModel
 from steamship.plugin.outputs.raw_data_plugin_output import RawDataPluginOutput
 
 
@@ -19,13 +18,13 @@ def test_dump_json():
     assert json.dumps(flexi_create(json=[1, 2, 3])[0]) == "[1, 2, 3]"
     assert json.dumps(flexi_create(json={"hi": "there"})[0]) == '{"hi": "there"}'
 
-    class Person(BaseModel):
+    class Person(CamelModel):
         name: str
 
     person = Person(name="Ted")
     assert json.dumps(flexi_create(json=person)[0]) == '{"name": "Ted"}'
 
-    class Person2(BaseModel):
+    class Person2(CamelModel):
         name: str
 
         def to_dict(self):
@@ -49,7 +48,7 @@ def test_dump_raw_data():
     json_str = _base64_decode(obj.data)
     assert json_str == '{"hi": "there"}'
 
-    class Person(BaseModel):
+    class Person(CamelModel):
         name: str
 
     person = Person(name="Ted")

--- a/tests/tests/base/test_task.py
+++ b/tests/tests/base/test_task.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
-
+from steamship.base.configuration import CamelModel
 from steamship.base.tasks import TaskState
 from tests.utils.fixtures import get_steamship_client
 
 
-class NoOpResult(BaseModel):
+class NoOpResult(CamelModel):
     pass
 
 

--- a/tests/tests/plugin/unit/test_service.py
+++ b/tests/tests/plugin/unit/test_service.py
@@ -44,7 +44,7 @@ class ValidTrainableStringToStringModel(TrainableModel[EmptyConfig]):
 
 class ValidTrainableStringToStringPlugin(TrainableTagger):
     def train_status(
-            self, request: PluginRequest[TrainStatusPluginInput], model: TrainableModel
+        self, request: PluginRequest[TrainStatusPluginInput], model: TrainableModel
     ) -> Response[TrainPluginOutput]:
         return Response(data=TrainPluginOutput(training_complete=True))
 
@@ -58,12 +58,12 @@ class ValidTrainableStringToStringPlugin(TrainableTagger):
         return self.client
 
     def run_with_model(
-            self, request: PluginRequest[str], model: TrainableModel
+        self, request: PluginRequest[str], model: TrainableModel
     ) -> Union[str, Response[str]]:
         pass
 
     def get_training_parameters(
-            self, request: PluginRequest[TrainingParameterPluginInput]
+        self, request: PluginRequest[TrainingParameterPluginInput]
     ) -> Response[TrainingParameterPluginOutput]:
         return Response(data=TrainingParameterPluginOutput())
 
@@ -71,7 +71,7 @@ class ValidTrainableStringToStringPlugin(TrainableTagger):
         return Response(data=TrainPluginOutput(training_complete=True))
 
     def train_status(
-            self, request: PluginRequest[TrainStatusPluginInput], model
+        self, request: PluginRequest[TrainStatusPluginInput], model
     ) -> Response[TrainPluginOutput]:
         return Response(data=TrainPluginOutput(training_complete=True))
 
@@ -88,6 +88,7 @@ def test_plugin_service_is_abstract():
 
 def test_plugin_service_must_implement_run_and_subclass_request_from_dict():
     with pytest.raises(Exception):
+
         class BadPlugin(PluginService):
             pass
 

--- a/tests/utils/fixtures.py
+++ b/tests/utils/fixtures.py
@@ -60,11 +60,11 @@ def app_handler(request) -> Callable[[str, str, Optional[dict]], dict]:
     def handle(verb: str, app_path: str, arguments: Optional[dict] = None) -> dict:
         _handler = _create_handler(app)
         invocation = Invocation(httpVerb=verb, appPath=app_path, arguments=arguments or dict())
-        loggingConfig = LoggingConfig(loggingHost="none", loggingPort="none")
+        logging_config = LoggingConfig(loggingHost="none", loggingPort="none")
         request = Request(
-            clientConfig=new_client.config, invocation=invocation, loggingConfig=loggingConfig
+            client_config=new_client.config, invocation=invocation, logging_config=logging_config
         )
-        event = request.dict()
+        event = request.dict(by_alias=True)
         return _handler(event)
 
     yield handle

--- a/tests/utils/test_enums.py
+++ b/tests/utils/test_enums.py
@@ -4,7 +4,7 @@ __license__ = "MIT"
 import json
 from enum import Enum
 
-from pydantic import BaseModel
+from steamship.base.configuration import CamelModel
 
 
 class TrainingPlatform(str, Enum):
@@ -14,7 +14,7 @@ class TrainingPlatform(str, Enum):
     LAMBDA = "lambda"
 
 
-class PluginInstance(BaseModel):
+class PluginInstance(CamelModel):
     training_platform: TrainingPlatform
 
 


### PR DESCRIPTION
Title says it all. 

Reasons to do this: 

- All comms with server happen in camelCase. 
- Picking 1 option over 2 leaves less room for surprises 
- CamelModel works just like BaseModel without the `by_alias=True` option

Going to develop a pre-commit hook that checks if we are using BaseModel in the future. 