### PR TITLE
Install both deps and development deps with upgrade options

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -46,7 +46,10 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install Development Dependencies
-        run: python -m pip install -r requirements.dev.txt
+        run: python -m pip install --upgrade -r requirements.dev.txt
+
+      - name: Install Dependencies
+        run: python -m pip install --upgrade -r requirements.txt
 
       - name: Lint
         run: pre-commit run --all-files --color always

--- a/.github/workflows/test-staging.yml
+++ b/.github/workflows/test-staging.yml
@@ -46,7 +46,10 @@ jobs:
           restore-keys: ${{ runner.os }}-pip-
 
       - name: Install Development Dependencies
-        run: python -m pip install -r requirements.dev.txt
+        run: python -m pip install --upgrade -r requirements.dev.txt
+
+      - name: Install Dependencies
+        run: python -m pip install --upgrade -r requirements.txt
 
       - name: Lint
         run: pre-commit run --all-files --color always


### PR DESCRIPTION
1) Installs both requirements.txt and requirements.dev.txt in GH Actions testing. 
2) Uses --upgrade option to suppress warnings in GHA logging output