### PR TITLE
Fix bug in logging formatter

### DIFF
--- a/src/steamship/app/lambda_handler.py
+++ b/src/steamship/app/lambda_handler.py
@@ -136,7 +136,7 @@ def create_handler(app_cls: Type[App]):  # noqa: C901
             custom_format = {
                 "level": "%(levelname)s",
                 "host": "%(hostname)s",
-                "where": "%(module)s.%(filename).%(funcName)s:%(lineno)s",
+                "where": "%(module)s.%(filename)s.%(funcName)s:%(lineno)s",
                 "type": "%(levelname)s",
                 "stack_trace": "%(exc_text)s",
                 "component": "app-plugin-lambda",


### PR DESCRIPTION
A missing `s` was causing every call to `log.*` to crash the whole lambda!