### PR TITLE
Python sdk changes for large FileImport

### DIFF
--- a/src/steamship/app/app.py
+++ b/src/steamship/app/app.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 
 from steamship.app.request import Request
 from steamship.app.response import Response
-from steamship.base import Client
+from steamship.client import Steamship
 from steamship.utils.url import Verb
 
 
@@ -84,7 +84,7 @@ class App:
 
     _method_mappings = defaultdict(dict)
 
-    def __init__(self, client: Client = None, config: Dict[str, Any] = None):
+    def __init__(self, client: Steamship = None, config: Dict[str, Any] = None):
         self.client = client
         self.config = config
 

--- a/src/steamship/plugin/outputs/raw_data_plugin_output.py
+++ b/src/steamship/plugin/outputs/raw_data_plugin_output.py
@@ -43,20 +43,23 @@ class RawDataPluginOutput(CamelModel):
         **kwargs,
     ):
         super().__init__()
-        self.url = url
-        if base64string is not None:
-            self.data = base64string
+        if url is not None:
+            self.url = url
             self.mime_type = mime_type or MimeTypes.BINARY
         else:
-            # Base64-encode the data field.
-            self.data, self.mime_type, encoding = flexi_create(
-                base64string=base64string,
-                string=string,
-                json=json,
-                _bytes=_bytes,
-                mime_type=mime_type,
-                force_base64=True,
-            )
+            if base64string is not None:
+                self.data = base64string
+                self.mime_type = mime_type or MimeTypes.BINARY
+            else:
+                # Base64-encode the data field.
+                self.data, self.mime_type, encoding = flexi_create(
+                    base64string=base64string,
+                    string=string,
+                    json=json,
+                    _bytes=_bytes,
+                    mime_type=mime_type,
+                    force_base64=True,
+                )
 
     @classmethod
     def parse_obj(cls: Type[BaseModel], obj: Any) -> BaseModel:

--- a/src/steamship/plugin/outputs/raw_data_plugin_output.py
+++ b/src/steamship/plugin/outputs/raw_data_plugin_output.py
@@ -11,7 +11,7 @@ from steamship.base.configuration import CamelModel
 
 
 class RawDataPluginOutput(CamelModel):
-    """Represents mime-typed raw data that can be returned to the engine.
+    """Represents mime-typed raw data (or a URL pointing to raw data) that can be returned to the engine.
 
     As a few examples, you can return:
     - Raw text: RawDataPluginOutput(string=raw_text, MimeTypes.TXT)
@@ -19,6 +19,7 @@ class RawDataPluginOutput(CamelModel):
     - A PNG image: RawDataPluginOutput(bytes=png_bytes, MimeTypes.PNG)
     - A JSON-serializable Dataclass: RawDataPluginOutput(json=dataclass, MimeTypes.JSON)
     - Steamship Blocks: RawDataPluginOutput(json=file, MimeTypes.STEAMSHIP_BLOCK_JSON)
+    - Data uploaded to a pre-signed URL: RawDataPluginOutput(url=presigned_url, MimeTypes.TXT)
 
     The `data` field of this object will ALWAYS be Base64 encoded by the constructor. This ensures that the object
     is always trivially JSON-serializable over the wire, no matter what it contains.
@@ -29,6 +30,7 @@ class RawDataPluginOutput(CamelModel):
 
     data: Optional[str] = None  # Note: This is **always** Base64 encoded.
     mime_type: Optional[str] = None
+    url: Optional[str] = None
 
     def __init__(
         self,
@@ -37,9 +39,11 @@ class RawDataPluginOutput(CamelModel):
         _bytes: Union[bytes, io.BytesIO] = None,
         json: Any = None,
         mime_type: str = None,
+        url: str = None,
         **kwargs,
     ):
         super().__init__()
+        self.url = url
         if base64string is not None:
             self.data = base64string
             self.mime_type = mime_type or MimeTypes.BINARY

--- a/src/steamship/plugin/service.py
+++ b/src/steamship/plugin/service.py
@@ -8,7 +8,6 @@ from pydantic.generics import GenericModel
 
 from steamship.app import App
 from steamship.app.response import Response
-from steamship.base import Client
 
 # Note!
 # =====
@@ -17,6 +16,7 @@ from steamship.base import Client
 # If you are using the Steamship Client, you probably are looking for either steamship.client or steamship.data
 #
 from steamship.base.utils import to_camel
+from steamship.client import Steamship
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
 from steamship.plugin.inputs.train_status_plugin_input import TrainStatusPluginInput
 from steamship.plugin.inputs.training_parameter_plugin_input import TrainingParameterPluginInput
@@ -73,7 +73,7 @@ class PluginService(ABC, App, Generic[T, U]):
     """
 
     # noinspection PyUnusedLocal
-    def __init__(self, client: Client = None, config: Dict[str, Any] = None):
+    def __init__(self, client: Steamship = None, config: Dict[str, Any] = None):
         super().__init__(client, config)
 
     @abstractmethod
@@ -87,7 +87,7 @@ class PluginService(ABC, App, Generic[T, U]):
 
 class TrainablePluginService(App, ABC, Generic[T, U]):
     # noinspection PyUnusedLocal
-    def __init__(self, client: Client = None, config: Dict[str, Any] = None):
+    def __init__(self, client: Steamship = None, config: Dict[str, Any] = None):
         super().__init__(client, config)
 
     @abstractmethod

--- a/tests/assets/apps/demo_app.py
+++ b/tests/assets/apps/demo_app.py
@@ -4,9 +4,9 @@ from typing import Any, Dict
 
 from steamship import SteamshipError
 from steamship.app import App, Response, create_handler, get, post
-from steamship.base import Client
 from steamship.base.configuration import CamelModel
 from steamship.base.mime_types import MimeTypes
+from steamship.client import Steamship
 from steamship.data.user import User
 
 
@@ -20,7 +20,7 @@ PALM_TREE_BASE_64 = PALM_TREE_BASE_64.encode("ascii")
 
 
 class TestApp(App):
-    def __init__(self, client: Client = None, config: Dict[str, Any] = None):
+    def __init__(self, client: Steamship = None, config: Dict[str, Any] = None):
         super().__init__(client, config)
         self.index = None
 

--- a/tests/assets/plugins/importers/plugin_file_importer_by_url.py
+++ b/tests/assets/plugins/importers/plugin_file_importer_by_url.py
@@ -1,0 +1,47 @@
+import logging
+import uuid
+from typing import Type
+
+from steamship import MimeTypes
+from steamship.app import Response, create_handler
+from steamship.data.space import SignedUrl
+from steamship.plugin.config import Config
+from steamship.plugin.file_importer import FileImporter
+from steamship.plugin.inputs.file_import_plugin_input import FileImportPluginInput
+from steamship.plugin.outputs.raw_data_plugin_output import RawDataPluginOutput
+from steamship.plugin.service import PluginRequest
+from steamship.utils.signed_urls import upload_to_signed_url
+
+# Note: this aligns with the same document in the internal Engine test.
+HANDLE = "test-importer-plugin-v1"
+TEST_H1 = "A Poem"
+TEST_S1 = "Roses are red."
+TEST_S2 = "Violets are blue."
+TEST_S3 = "Sugar is sweet, and I love you."
+TEST_DOC = f"# {TEST_H1}\n\n{TEST_S1} {TEST_S2}\n\n{TEST_S3}\n"
+
+
+class TestFileImporterPlugin(FileImporter):
+    class EmptyConfig(Config):
+        pass
+
+    def config_cls(self) -> Type[Config]:
+        return self.EmptyConfig
+
+    def run(self, request: PluginRequest[FileImportPluginInput]) -> Response[RawDataPluginOutput]:
+        filepath = str(uuid.uuid4())
+        response = self.client.get_space().create_signed_url(
+            SignedUrl.Request(
+                bucket=SignedUrl.Bucket.PLUGIN_DATA,
+                filepath=filepath,
+                operation=SignedUrl.Operation.WRITE,
+            )
+        )
+        signed_url = response.data.signed_url
+        logging.info(f"Got signed url for writing: {signed_url}")
+        bytes = TEST_DOC.encode("utf-8")
+        upload_to_signed_url(signed_url, bytes)
+        return Response(data=RawDataPluginOutput(url=signed_url, mime_type=MimeTypes.MKD))
+
+
+handler = create_handler(TestFileImporterPlugin)

--- a/tests/steamship_tests/plugin/integration/test_e2e_file_importer_by_url.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_file_importer_by_url.py
@@ -1,0 +1,25 @@
+import pytest
+from assets.plugins.blockifiers.blockifier import TEST_DOC
+from steamship_tests import PLUGINS_PATH
+from steamship_tests.utils.deployables import deploy_plugin
+
+from steamship import File
+from steamship.client import Steamship
+
+
+@pytest.mark.usefixtures("client")
+def test_e2e_importer(client: Steamship):
+    file_importer_path = PLUGINS_PATH / "importers" / "plugin_file_importer_by_url.py"
+    with deploy_plugin(client, file_importer_path, "fileImporter") as (
+        plugin,
+        version,
+        instance,
+    ):
+        # The test FileImporter should always return a string file with contents TEST_DOC
+        file = File.create(client=client, content="Unused", plugin_instance=instance.handle).data
+
+        # Now fetch the data from Steamship and assert that it is the SAME as the data the FileImporter creates
+        data = file.raw().data
+        assert data.decode("utf-8") == TEST_DOC
+
+        file.delete()


### PR DESCRIPTION
This PR allows large file imports beyond the size limit of lambda return values.  The FileImporter plugin must create a steamship signed URL, and pass that as a return value in RawDataPluginOutput.

Along the way, I had to make a change so that Plugins/Apps would get a handle to a Steamship object instead of a Client object.

Depends on engine PR #304.